### PR TITLE
Update version 1.0.0a7

### DIFF
--- a/jupyter-cpp-kernel/kernel.py
+++ b/jupyter-cpp-kernel/kernel.py
@@ -92,7 +92,7 @@ class CPPKernel(Kernel):
                      'file_extension': '.cpp'
                     }
     
-    introduction = "C++ 14 kernel for Jupyter (master), version 1.0.0a6\n\n"
+    introduction = "C++ 14 kernel for Jupyter (master), version 1.0.0a7\n\n"
     cp_banner = "Copyright (C) 2024 shiroinekotfs\nCopyright (C) Brendan Rius\nCopyright (C) Free Software Foundation, Inc\n\n"
     links_guide = "Legal information: https://github.com/shiroinekotfs/jupyter-cpp-kernel/blob/master/LICENSE\nNotebook tutorial: https://github.com/shiroinekotfs/jupyter-cpp-kernel-doc\n\nAuthor GitHub profile: https://github.com/shiroinekotfs\n"
     reporting_links = "Reporting the issue: https://github.com/shiroinekotfs/jupyter-cpp-kernel/issues"
@@ -136,7 +136,10 @@ class CPPKernel(Kernel):
         return file
 
     def _write_to_stdout(self, contents):
-        contents = contents.replace("\r\n", "\r\n\r\n")
+        if os.name == 'nt':
+            contents = contents.replace("\r\n", "\r\n\r\n")
+        else:
+            contents = contents.replace("\n", "\n\n")
         self.send_response(self.iopub_socket, 
                            'display_data',
                            {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 description-file = README.md
 name = jupyter-cpp-kernel
-version = 1.0.0a6
+version = 1.0.0a7
 author = shiroinekotfs (ft. Brendan Rius)
 author_email = shiroineko.tfs@gmail.com
 description = C++ kernel for Jupyter. Easily adopt and deploy for testing environment.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='jupyter-cpp-kernel',
-      version='1.0.0a6',
+      version='1.0.0a7',
       description='C++ 14 kernel for Jupyter',
       author='shiroinekotfs',
       author_email='shiroineko.tfs@gmail.com',


### PR DESCRIPTION
Hotfix for #22. This PR is missing the break-lines command for Linux and Unix.