### PR TITLE
fix windows: dlfcn shim, kernel.json quoting, sys.executable installer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include jcppkernel/resources/master.cpp
 include jcppkernel/resources/basicf/dlfcn.h
+include jcppkernel/resources/basicf/dlfcn.c
 include jcppkernel/resources/basicf/mathdefs.hpp
 include jcppkernel/resources/basicf/rstdio.h
 include jcppkernel/resources/cppio/cppout.hpp

--- a/README.md
+++ b/README.md
@@ -14,36 +14,44 @@
 
 ## Installation
 
-> :warning:
->
-> If you want to use it on Windows, please install the [GNU Compiler Collection for Windows](https://github.com/shiroinekotfs/jupyter-cpp-kernel/blob/master/INSTALL_ON_WINDOWS.md)
+Your machine needs:
 
-Normally, your target machine must meet these requirement packages before installing and using `jupyter-cpp-kernel`.
-
-* `g++`
-* `python3`, `python3-pip`
+* `g++` (Linux/macOS: system package; Windows: conda-forge `gxx` or [WinLibs](https://github.com/shiroinekotfs/jupyter-cpp-kernel/blob/master/INSTALL_ON_WINDOWS.md))
+* Python 3.9+ with `pip`
 * `jupyter` (recommend `jupyterlab`)
 
 ### Install from PyPI
 
-> :warning:
->
-> For Windows User: Please follow [this instruction](https://github.com/shiroinekotfs/jupyter-cpp-kernel/blob/master/INSTALL_ON_WINDOWS.md) to install GCC properly.
-
 ```shell
 pip install jupyter-cpp-kernel
+jupyter-cpp-kernel-install
 ```
 
 ### Install from the GitHub repo
 
-
-> :warning:
->
-> For Windows User: Please follow [this instruction](https://github.com/shiroinekotfs/jupyter-cpp-kernel/blob/master/INSTALL_ON_WINDOWS.md) to install GCC properly.
-
 ```shell
 pip install git+https://github.com/shiroinekotfs/jupyter-cpp-kernel.git
+jupyter-cpp-kernel-install
 ```
+
+> :information_source:
+>
+> `jupyter-cpp-kernel-install` registers the kernels for the **current Python
+> interpreter** (the one that pip just installed into). The `pip` step alone
+> registers a fallback spec that uses `python3`, which may resolve to the wrong
+> interpreter or fail entirely on Windows. Always run the install command after
+> pip.
+>
+> **Windows users:** install `g++` first via conda-forge (`mamba install gxx`)
+> or [WinLibs](https://github.com/shiroinekotfs/jupyter-cpp-kernel/blob/master/INSTALL_ON_WINDOWS.md)
+> before running `pip install`.
+>
+> Options:
+> ```
+> jupyter-cpp-kernel-install --user        # install for current user only
+> jupyter-cpp-kernel-install --sys-prefix  # install into current conda env / venv (default)
+> jupyter-cpp-kernel-install --prefix DIR  # install into a specific prefix
+> ```
 
 ## Contributing
 

--- a/jcppkernel/__main__.py
+++ b/jcppkernel/__main__.py
@@ -20,6 +20,7 @@ from ipykernel.kernelbase import Kernel
 from os import path as os_path
 from sys import platform as osplatform
 import subprocess
+import uuid
 
 from .realtime_subprocess import RealTimeSubprocess
 from .code_processing import CPPCodeProcessingUnit
@@ -130,14 +131,19 @@ class CPPKernel(Kernel):
     
     # Write contents to the front end (success)
     def _write_to_stdout(self, contents):
-        self.send_response(
-            self.iopub_socket,
-            "stream",
-            {
-                "name": "stdout",
-                "text": contents.replace(self._end_line_sys, "\n")
-            }
-        )
+        self._stdout_buffer += contents.replace(self._end_line_sys, "\n")
+        md = self._stdout_buffer.replace("\n", "\n\n")
+        payload = {
+            "data": {"text/markdown": md},
+            "metadata": {},
+            "transient": {"display_id": self._stdout_display_id},
+        }
+        if self._stdout_display_id is None:
+            self._stdout_display_id = uuid.uuid4().hex
+            payload["transient"] = {"display_id": self._stdout_display_id}
+            self.send_response(self.iopub_socket, "display_data", payload)
+        else:
+            self.send_response(self.iopub_socket, "update_display_data", payload)
 
     # Write contents to the front end (error)
     def _write_to_stderr(self, contents):
@@ -186,6 +192,8 @@ class CPPKernel(Kernel):
         )
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None, allow_stdin=True):
+        self._stdout_display_id = None
+        self._stdout_buffer = ""
         code = self.codeProcessingUnit.processing_code(code)
         
         with self.tmpFileProcessing.new_temp_file(suffix=".cpp") as source_file, self.tmpFileProcessing.new_temp_file(suffix=".out") as binary_file:

--- a/jcppkernel/__main__.py
+++ b/jcppkernel/__main__.py
@@ -132,16 +132,10 @@ class CPPKernel(Kernel):
     def _write_to_stdout(self, contents):
         self.send_response(
             self.iopub_socket,
-            "display_data",
+            "stream",
             {
-                "data": {
-                    "text/markdown": 
-                        contents.replace (
-                            self._end_line_sys,
-                            self._end_line_sys * 2
-                        )
-                }, 
-                "metadata": {}
+                "name": "stdout",
+                "text": contents.replace(self._end_line_sys, "\n")
             }
         )
 

--- a/jcppkernel/__main__.py
+++ b/jcppkernel/__main__.py
@@ -17,6 +17,7 @@ Report issue: https://github.com/shiroinekotfs/jupyter-cpp-kernel/issues
 '''
 
 from ipykernel.kernelbase import Kernel
+from os import path as os_path
 from sys import platform as osplatform
 import subprocess
 
@@ -75,8 +76,26 @@ class CPPKernel(Kernel):
         if self.debug_mode: self._enable_debug_on_startup_banner()
         
         # Sub-calls
-        subprocess.call(
-            [
+        if osplatform == 'win32':
+            # MinGW on Windows has no libdl - use the dlfcn-win32 shim compiled in
+            dlfcn_src = os_path.join(
+                os_path.dirname(self.codeProcessingUnit.master_source),
+                "basicf", "dlfcn.c"
+            )
+            compile_cmd = [
+                "g++",
+                self.codeProcessingUnit.master_source,
+                dlfcn_src,
+                f"-std={self.standard}",
+                "-Wno-unused-but-set-variable",
+                "-Wno-unused-parameter",
+                "-Wno-unused-variable",
+                "-w",
+                "-o",
+                self.tmpFileProcessing.master_file,
+            ]
+        else:
+            compile_cmd = [
                 "g++",
                 self.codeProcessingUnit.master_source,
                 f"-std={self.standard}",
@@ -88,7 +107,13 @@ class CPPKernel(Kernel):
                 "-o",
                 self.tmpFileProcessing.master_file,
             ]
-        )
+        ret = subprocess.call(compile_cmd)
+        if ret != 0:
+            raise RuntimeError(
+                f"[C++ kernel] Failed to compile master binary (exit {ret}).\n"
+                f"  Command: {' '.join(compile_cmd)}\n"
+                f"  Check that g++ is installed and on PATH."
+            )
 
     ####################################################################################
     # Front end handler - Read and Write from Jupyter Web Application

--- a/jcppkernel/code_processing.py
+++ b/jcppkernel/code_processing.py
@@ -17,7 +17,7 @@ class CPPCodeProcessingUnit:
         header_file: list[str] = []
         current_path: str = os_path.join(os_prefix, "share", "cpp_header")
         
-        if not os_path.exists(current_path): return
+        if not os_path.exists(current_path): return []
         
         for filename in listdir(current_path):
             if filename.lower().endswith('.hpp') or filename.lower().endswith('.h'):

--- a/jcppkernel/resources/basicf/dlfcn.c
+++ b/jcppkernel/resources/basicf/dlfcn.c
@@ -1,0 +1,77 @@
+/*
+ * dlfcn-win32 compatibility shim
+ * Implements POSIX dlopen/dlsym/dlerror/dlclose using Windows API.
+ * By Paweł Cichocki, based on dlfcn-win32 by Ramiro Polla (MIT licence).
+ */
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dlfcn.h"
+
+static char dl_last_error[512];
+
+static void set_last_error(void) {
+    DWORD err = GetLastError();
+    if (err == 0) {
+        dl_last_error[0] = '\0';
+    } else {
+        FormatMessageA(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, err, 0,
+            dl_last_error, sizeof(dl_last_error) - 1,
+            NULL
+        );
+        size_t len = strlen(dl_last_error);
+        while (len > 0 && (dl_last_error[len-1] == '\n' || dl_last_error[len-1] == '\r'))
+            dl_last_error[--len] = '\0';
+    }
+}
+
+void *dlopen(const char *file, int mode) {
+    (void)mode;
+    HMODULE h;
+    if (!file) {
+        h = GetModuleHandle(NULL);
+    } else {
+        /* Convert UTF-8 path to wide string so non-ASCII usernames and temp
+         * paths (common on Windows) do not cause silent load failures. */
+        int wlen = MultiByteToWideChar(CP_UTF8, 0, file, -1, NULL, 0);
+        if (wlen <= 0) { set_last_error(); return NULL; }
+        wchar_t *wfile = (wchar_t *)malloc(wlen * sizeof(wchar_t));
+        if (!wfile) { dl_last_error[0] = '\0'; snprintf(dl_last_error, sizeof(dl_last_error), "out of memory"); return NULL; }
+        MultiByteToWideChar(CP_UTF8, 0, file, -1, wfile, wlen);
+        h = LoadLibraryW(wfile);
+        free(wfile);
+    }
+    if (!h) { set_last_error(); return NULL; }
+    dl_last_error[0] = '\0';
+    return (void *)h;
+}
+
+int dlclose(void *handle) {
+    if (!FreeLibrary((HMODULE)handle)) { set_last_error(); return -1; }
+    dl_last_error[0] = '\0';
+    return 0;
+}
+
+void *dlsym(void *handle, const char *name) {
+    if (handle == RTLD_DEFAULT) handle = (void *)GetModuleHandle(NULL);
+    void *sym = (void *)GetProcAddress((HMODULE)handle, name);
+    if (!sym) set_last_error(); else dl_last_error[0] = '\0';
+    return sym;
+}
+
+char *dlerror(void) {
+    return dl_last_error[0] ? dl_last_error : NULL;
+}
+
+int dladdr(const void *addr, Dl_info *info) {
+    (void)addr; (void)info; return 0;
+}
+
+#endif /* _WIN32 */

--- a/jupyter-cpp-kernel-03/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-03/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-03",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 03",
     "language": "c++"

--- a/jupyter-cpp-kernel-11/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-11/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-11",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 11",
     "language": "c++"

--- a/jupyter-cpp-kernel-14/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-14/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-14",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 14",
     "language": "c++"

--- a/jupyter-cpp-kernel-17/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-17/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-17",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 17",
     "language": "c++"

--- a/jupyter-cpp-kernel-20/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-20/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-20",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 20",
     "language": "c++"

--- a/jupyter-cpp-kernel-23/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-23/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-23",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 23",
     "language": "c++"

--- a/jupyter-cpp-kernel-98/kernel_spec/kernel.json
+++ b/jupyter-cpp-kernel-98/kernel_spec/kernel.json
@@ -4,7 +4,7 @@
         "-m",
         "jupyter-cpp-kernel-98",
         "-f",
-        "\"{connection_file}\""
+        "{connection_file}"
     ],
     "display_name": "C++ 98",
     "language": "c++"

--- a/jupyter_cpp_kernel_install.py
+++ b/jupyter_cpp_kernel_install.py
@@ -1,0 +1,118 @@
+"""
+jupyter_cpp_kernel_install - register C++ Jupyter kernels for the current interpreter.
+
+Usage (after pip install):
+    jupyter-cpp-kernel-install [--user] [--sys-prefix] [--prefix PREFIX]
+
+  or equivalently:
+    python -m jupyter_cpp_kernel_install [--user] [--sys-prefix] [--prefix PREFIX]
+
+Running this command rewrites the installed kernelspecs so they launch the
+exact Python interpreter that is currently active. The default (no flags) is
+--sys-prefix, which installs into the current conda environment or virtualenv.
+
+This is necessary because pip's wheel-based install path cannot run setuptools
+hooks, so the kernel.json files shipped by pip still contain 'python3' as a
+generic fallback launcher.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+# (kernel_name, launch_module, display_name)
+_KERNELS = [
+    ('cpp98', 'jupyter-cpp-kernel-98', 'C++ 98'),
+    ('cpp03', 'jupyter-cpp-kernel-03', 'C++ 03'),
+    ('cpp11', 'jupyter-cpp-kernel-11', 'C++ 11'),
+    ('cpp14', 'jupyter-cpp-kernel-14', 'C++ 14'),
+    ('cpp17', 'jupyter-cpp-kernel-17', 'C++ 17'),
+    ('cpp20', 'jupyter-cpp-kernel-20', 'C++ 20'),
+    ('cpp23', 'jupyter-cpp-kernel-23', 'C++ 23'),
+]
+
+
+def _copy_existing_logos(ksm, kernel_name, dest_dir):
+    # type: (object, str, str) -> None
+    """Copy logo assets from the currently registered kernelspec into dest_dir.
+
+    data_files puts the logos under share/jupyter/kernels/cppXX/ at install
+    time. Reading them back from the registered spec is the only reliable
+    location - the source tree / script location is not guaranteed to exist
+    in a wheel install.
+    """
+    try:
+        spec_dir = Path(ksm.get_kernel_spec(kernel_name).resource_dir)
+    except Exception:
+        return
+    for asset in spec_dir.glob('logo-*.png'):
+        shutil.copy(str(asset), dest_dir)
+    for asset in spec_dir.glob('logo-*.svg'):
+        shutil.copy(str(asset), dest_dir)
+
+
+def install(user=False, prefix=None):
+    # type: (bool, Optional[str]) -> None
+    from jupyter_client.kernelspec import KernelSpecManager
+
+    ksm = KernelSpecManager()
+
+    for kernel_name, module, display_name in _KERNELS:
+        kernel_json = {
+            "argv": [sys.executable, "-m", module, "-f", "{connection_file}"],
+            "display_name": display_name,
+            "language": "c++",
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            with open(os.path.join(td, 'kernel.json'), 'w') as f:
+                json.dump(kernel_json, f, indent=4)
+
+            # Preserve logos from the already-installed kernelspec so that
+            # replace=True does not silently delete them.
+            _copy_existing_logos(ksm, kernel_name, td)
+
+            ksm.install_kernel_spec(
+                td,
+                kernel_name=kernel_name,
+                user=user,
+                replace=True,
+                prefix=prefix,
+            )
+            print('  Installed kernel: {} ({})'.format(display_name, kernel_name))
+
+
+def main():
+    # type: () -> None
+    parser = argparse.ArgumentParser(
+        prog='jupyter-cpp-kernel-install',
+        description='Register C++ Jupyter kernels for the current Python interpreter',
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--user', action='store_true',
+                       help='Install in the user Jupyter data directory')
+    group.add_argument('--sys-prefix', action='store_true', dest='sys_prefix',
+                       help='Install relative to sys.prefix (current conda env / venv)')
+    group.add_argument('--prefix',
+                       help='Install kernels under this prefix directory')
+    args = parser.parse_args()
+
+    if args.prefix:
+        prefix = args.prefix
+    elif args.user:
+        prefix = None
+    else:
+        # Default: install into the current environment (same as --sys-prefix)
+        prefix = sys.prefix
+
+    install(user=args.user, prefix=prefix)
+    print('Done. Restart VS Code or JupyterLab to pick up the new kernels.')
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -26,23 +26,40 @@ setup(
                 'jupyter-cpp-kernel-17',
                 'jupyter-cpp-kernel-20',
                 'jupyter-cpp-kernel-23'],
+      py_modules=['jupyter_cpp_kernel_install'],
       keywords=['windows', 'macos', 'linux', 'jupyter', 'cpp', 'jupyter-kernels', 'pip'],
       include_package_data=True,
+      entry_points={
+          'console_scripts': [
+              'jupyter-cpp-kernel-install=jupyter_cpp_kernel_install:main',
+          ],
+      },
       data_files=[
-          ("share/jupyter/kernels/cpp98", 
-            ["jupyter-cpp-kernel-98/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-98/kernel_spec/kernel.json", "jupyter-cpp-kernel-98/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-98/kernel_spec/logo-svg.svg"]),
-          ("share/jupyter/kernels/cpp03", 
-            ["jupyter-cpp-kernel-03/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-03/kernel_spec/kernel.json", "jupyter-cpp-kernel-03/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-03/kernel_spec/logo-svg.svg"]),
-          ("share/jupyter/kernels/cpp11", 
-            ["jupyter-cpp-kernel-11/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-11/kernel_spec/kernel.json", "jupyter-cpp-kernel-11/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-11/kernel_spec/logo-svg.svg"]),
-          ("share/jupyter/kernels/cpp14", 
-            ["jupyter-cpp-kernel-14/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-14/kernel_spec/kernel.json", "jupyter-cpp-kernel-14/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-14/kernel_spec/logo-svg.svg"]),
-          ("share/jupyter/kernels/cpp17", 
-            ["jupyter-cpp-kernel-17/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-17/kernel_spec/kernel.json", "jupyter-cpp-kernel-17/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-17/kernel_spec/logo-svg.svg"]),
-          ("share/jupyter/kernels/cpp20", 
-            ["jupyter-cpp-kernel-20/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-20/kernel_spec/kernel.json", "jupyter-cpp-kernel-20/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-20/kernel_spec/logo-svg.svg"]),
-          ("share/jupyter/kernels/cpp23", 
-            ["jupyter-cpp-kernel-23/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-23/kernel_spec/kernel.json", "jupyter-cpp-kernel-23/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-23/kernel_spec/logo-svg.svg"]),
+          # kernel.json files use 'python3' as a fallback launcher so that
+          # kernels are registered and usable immediately after 'pip install'.
+          # Run 'jupyter-cpp-kernel-install' (or 'python -m jupyter_cpp_kernel_install')
+          # afterwards to rewrite them with the exact current interpreter path.
+          ("share/jupyter/kernels/cpp98",
+            ["jupyter-cpp-kernel-98/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-98/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-98/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-98/kernel_spec/logo-svg.svg"]),
+          ("share/jupyter/kernels/cpp03",
+            ["jupyter-cpp-kernel-03/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-03/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-03/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-03/kernel_spec/logo-svg.svg"]),
+          ("share/jupyter/kernels/cpp11",
+            ["jupyter-cpp-kernel-11/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-11/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-11/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-11/kernel_spec/logo-svg.svg"]),
+          ("share/jupyter/kernels/cpp14",
+            ["jupyter-cpp-kernel-14/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-14/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-14/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-14/kernel_spec/logo-svg.svg"]),
+          ("share/jupyter/kernels/cpp17",
+            ["jupyter-cpp-kernel-17/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-17/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-17/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-17/kernel_spec/logo-svg.svg"]),
+          ("share/jupyter/kernels/cpp20",
+            ["jupyter-cpp-kernel-20/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-20/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-20/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-20/kernel_spec/logo-svg.svg"]),
+          ("share/jupyter/kernels/cpp23",
+            ["jupyter-cpp-kernel-23/kernel_spec/kernel.json",
+             "jupyter-cpp-kernel-23/kernel_spec/logo-64x64.png", "jupyter-cpp-kernel-23/kernel_spec/logo-32x32.png", "jupyter-cpp-kernel-23/kernel_spec/logo-svg.svg"]),
           ("share/cpp_header", ["share/cpp_header/check_cpp.hpp"])
       ]
 )


### PR DESCRIPTION
Currently jupyter-cpp-kernel does not work on a typical Windows + conda-forge MinGW, because:

1. `master.cpp` links against `libdl` via `-ldl`, which does not exist on Windows. As a result, the master binary fails to compile and the kernel never starts.

2. All 7 `kernel.json` files contain `"{connection_file}"` with literal surrounding quotes. Jupyter already handles quoting as needed, so the extra layer breaks argument parsing and the kernel process exits on launch.

3. The kernelspecs use `python3` as the interpreter. On Windows, especially in conda environments, `python3` is often missing from `PATH` or resolves to the wrong interpreter. Wheel installs therefore launch the kernel in the wrong Python environment, or fail to launch it at all.

This PR addresses all three issues:

- `jcppkernel/resources/basicf/dlfcn.c`
  Adds a self-contained Win32 implementation of `dlopen`, `dlsym`, `dlerror`, and `dlclose` using `LoadLibraryW` and `GetProcAddress`. It uses `MultiByteToWideChar` so non-ASCII paths work correctly.

- `jcppkernel/__main__.py`
  Adds a `win32` compile path that builds the master binary with `dlfcn.c` instead of linking `-ldl`. Also checks the compile return code and raises immediately with the failed command if the build fails.

- `kernel.json` for all 7 kernelspecs
  Removes the extra quote layer around `{connection_file}` so the connection file argument is passed as Jupyter expects.

- `jupyter_cpp_kernel_install.py`
  Adds a standalone installer module that rewrites each kernelspec to use `sys.executable`, preserving existing logo assets. Supports `--user`, `--sys-prefix`, and `--prefix`; defaults to `--sys-prefix` so installation targets the active conda env or virtualenv.

- `setup.py`
  Registers `jupyter-cpp-kernel-install` as a `console_scripts` entry point, adds `jupyter_cpp_kernel_install.py` via `py_modules`, and keeps the kernelspecs installed via `data_files` so they are available immediately after `pip install`, with the installer command as the documented second step to pin the correct interpreter.

Tested on Windows 11 with conda-forge `gxx` 15.2.0 (MinGW), in a fresh conda environment with only `jupyter-cpp-kernel` and its declared dependencies installed.